### PR TITLE
Add testing for calculate.js and operate.js

### DIFF
--- a/src/__tests__/calculate.test.js
+++ b/src/__tests__/calculate.test.js
@@ -1,0 +1,42 @@
+import calculate from "../logic/calculate";
+
+describe("Testing calculator object", ()=> {
+  test("Testing result", ()=> {
+    const obj = {
+      total: '10',
+      next: '5',
+      operation: 'x',
+    };
+    const btn = '=';
+
+    expect(
+     calculate(obj, btn).total 
+    ).toBe('50');
+  });
+
+  test("Testing operation", ()=> {
+    const obj = {
+      total: 0,
+      next: 4,
+      operation: null,
+    };
+    const btn = '+';
+
+    expect(
+     calculate(obj, btn).operation 
+    ).toBe('+');
+  });
+
+  test("Testing next", ()=> {
+    const obj = {
+      total: 0,
+      next: null,
+      operation: null,
+    };
+    const btn = '4';
+
+    expect(
+     calculate(obj, btn).next 
+    ).toBe('4');
+  });
+});

--- a/src/__tests__/calculate.test.js
+++ b/src/__tests__/calculate.test.js
@@ -1,7 +1,7 @@
-import calculate from "../logic/calculate";
+import calculate from '../logic/calculate';
 
-describe("Testing calculator object", ()=> {
-  test("Testing result", ()=> {
+describe('Testing calculator object', () => {
+  test('Testing result', () => {
     const obj = {
       total: '10',
       next: '5',
@@ -10,11 +10,11 @@ describe("Testing calculator object", ()=> {
     const btn = '=';
 
     expect(
-     calculate(obj, btn).total 
+      calculate(obj, btn).total,
     ).toBe('50');
   });
 
-  test("Testing operation", ()=> {
+  test('Testing operation', () => {
     const obj = {
       total: 0,
       next: 4,
@@ -23,11 +23,11 @@ describe("Testing calculator object", ()=> {
     const btn = '+';
 
     expect(
-     calculate(obj, btn).operation 
+      calculate(obj, btn).operation,
     ).toBe('+');
   });
 
-  test("Testing next", ()=> {
+  test('Testing next', () => {
     const obj = {
       total: 0,
       next: null,
@@ -36,7 +36,7 @@ describe("Testing calculator object", ()=> {
     const btn = '4';
 
     expect(
-     calculate(obj, btn).next 
+      calculate(obj, btn).next,
     ).toBe('4');
   });
 });

--- a/src/__tests__/operate.test.js
+++ b/src/__tests__/operate.test.js
@@ -1,0 +1,19 @@
+import operate from "../logic/operate";
+
+describe("Testing calculation", ()=>{
+  test("Test addition", ()=> {
+    const res = operate(2,2,'+');
+    expect(res).toBe('4');
+  });
+
+  test("Test subtraction", ()=> {
+    const res = operate(8,2,'-');
+    expect(res).toBe('6');
+  });
+
+  test("Test addition", ()=> {
+    const res = operate(2,7,'x');
+    expect(res).toBe('14');
+  });
+
+});

--- a/src/__tests__/operate.test.js
+++ b/src/__tests__/operate.test.js
@@ -1,19 +1,18 @@
-import operate from "../logic/operate";
+import operate from '../logic/operate';
 
-describe("Testing calculation", ()=>{
-  test("Test addition", ()=> {
-    const res = operate(2,2,'+');
+describe('Testing calculation', () => {
+  test('Test addition', () => {
+    const res = operate(2, 2, '+');
     expect(res).toBe('4');
   });
 
-  test("Test subtraction", ()=> {
-    const res = operate(8,2,'-');
+  test('Test subtraction', () => {
+    const res = operate(8, 2, '-');
     expect(res).toBe('6');
   });
 
-  test("Test addition", ()=> {
-    const res = operate(2,7,'x');
+  test('Test multiplication', () => {
+    const res = operate(2, 7, 'x');
     expect(res).toBe('14');
   });
-
 });


### PR DESCRIPTION
In this pull request:

- unit tests for the files operate.js and calculate.js using Jest
- Create unit tests for all React components:
- Use Jest snapshots to test the components.
- Use React Testing Library to simulate user interaction.